### PR TITLE
Remove usage of legacy codon-buildpacks buildpack URL

### DIFF
--- a/docker_support/install-jdk.sh
+++ b/docker_support/install-jdk.sh
@@ -1,5 +1,5 @@
 mkdir -p /opt/jvm-common
-curl --silent --location https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz | tar xzm -C /opt/jvm-common --strip-components=1
+curl --silent --location https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz | tar xzm -C /opt/jvm-common --strip-components=1
 source /opt/jvm-common/bin/util
 source /opt/jvm-common/bin/java
 mkdir -p /opt/jdk


### PR DESCRIPTION
The `codon-buildpacks` S3 bucket has been deprecated for many years, having been replaced by the buildpack registry shorthand aliases, which map to the `buildpack-registry` S3 bucket instead.

New buildpack releases are currently backported to the legacy `codon-buildpacks` bucket from `buildpack-registry` by a sync job (so this PR has no change on functionality), however that job will be sunset soon, causing `codon-buildpacks` to become stale.

GUS-W-10034067.