### PR TITLE
Reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
+# Default to requesting pull request reviews from the Heroku Languages team.
 * @heroku/languages
+
+# However, request review from the language owner instead for files that are
+# updated by Dependabot, to reduce team review request noise.
+Gemfile.lock @schneems


### PR DESCRIPTION
The `CODEOWNERS` file has been adjusted to request review from the primary repository maintainer for high-traffic files that are typically updated via automation, rather than requesting review from the whole team.

For more information, see:
https://github.com/heroku/heroku-buildpack-ruby/pull/1419

GUS-W-14941625.