### PR TITLE
[stacked] Remove unused directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ See https://github.com/heroku/docker-heroku-ruby-builder#building-with-github-ac
 Make sure you've generated a docker image:
 
 ```
-bundle exec rake "generate_image[heroku-22]"
+bin/activate_docker heroku-24
 ```
 
 Then run the following:
 
 ```
-bundle exec rake "new[9.3.0.0,heroku-22]" &&
-bash rubies/heroku-22/jruby-9.3.0.0.sh &&
-bundle exec rake "upload[9.3.0.0,heroku-22]" &&
-echo "Done building jruby 9.3.0.0 for heroku-22"
+bin/build_jruby heroku-24 9.4.7.0
+```
+
+This will generate tar files in the `builds` folder. You can exercise them by running:
+
+```
+bin/print_summary heroku-24 9.4.7.0
 ```

--- a/rubies/heroku-20/common.sh
+++ b/rubies/heroku-20/common.sh
@@ -1,5 +1,0 @@
-STACK=heroku-20
-OUTPUT_DIR=${OUTPUT_DIR:-`pwd`/builds/$STACK}
-
-echo "OUTPUT DIR: $OUTPUT_DIR"
-echo "STACK: $STACK"

--- a/rubies/heroku-20/ruby-2.2.3-jruby-9.0.5.0.sh
+++ b/rubies/heroku-20/ruby-2.2.3-jruby-9.0.5.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.0.5.0 -e RUBY_VERSION=2.2.3 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.5.7-jruby-9.2.14.0.sh
+++ b/rubies/heroku-20/ruby-2.5.7-jruby-9.2.14.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.14.0 -e RUBY_VERSION=2.5.7 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.5.7-jruby-9.2.15.0.sh
+++ b/rubies/heroku-20/ruby-2.5.7-jruby-9.2.15.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.15.0 -e RUBY_VERSION=2.5.7 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.5.7-jruby-9.2.16.0.sh
+++ b/rubies/heroku-20/ruby-2.5.7-jruby-9.2.16.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.16.0 -e RUBY_VERSION=2.5.7 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.5.8-jruby-9.2.17.0.sh
+++ b/rubies/heroku-20/ruby-2.5.8-jruby-9.2.17.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.17.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.5.8-jruby-9.2.18.0.sh
+++ b/rubies/heroku-20/ruby-2.5.8-jruby-9.2.18.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.18.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.5.8-jruby-9.2.19.0.sh
+++ b/rubies/heroku-20/ruby-2.5.8-jruby-9.2.19.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.19.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.5.8-jruby-9.2.21.0.sh
+++ b/rubies/heroku-20/ruby-2.5.8-jruby-9.2.21.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.21.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.0.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.0.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.0.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.10.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.10.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.10.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.3.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.3.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.3.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.4.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.4.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.4.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.5.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.5.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.5.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.6.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.6.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.6.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.7.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.7.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.7.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.8.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.8.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.8.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-2.6.8-jruby-9.3.9.0.sh
+++ b/rubies/heroku-20/ruby-2.6.8-jruby-9.3.9.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.9.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-3.1.0-jruby-9.4.0.0.sh
+++ b/rubies/heroku-20/ruby-3.1.0-jruby-9.4.0.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.4.0.0 -e RUBY_VERSION=3.1.0 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-20/ruby-3.1.0-jruby-9.4.1.0.sh
+++ b/rubies/heroku-20/ruby-3.1.0-jruby-9.4.1.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.4.1.0 -e RUBY_VERSION=3.1.0 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/common.sh
+++ b/rubies/heroku-22/common.sh
@@ -1,5 +1,0 @@
-STACK=heroku-22
-OUTPUT_DIR=${OUTPUT_DIR:-`pwd`/builds/$STACK}
-
-echo "OUTPUT DIR: $OUTPUT_DIR"
-echo "STACK: $STACK"

--- a/rubies/heroku-22/ruby-2.5.8-jruby-9.2.17.0.sh
+++ b/rubies/heroku-22/ruby-2.5.8-jruby-9.2.17.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.17.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.5.8-jruby-9.2.18.0.sh
+++ b/rubies/heroku-22/ruby-2.5.8-jruby-9.2.18.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.18.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.5.8-jruby-9.2.19.0.sh
+++ b/rubies/heroku-22/ruby-2.5.8-jruby-9.2.19.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.19.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.5.8-jruby-9.2.20.0.sh
+++ b/rubies/heroku-22/ruby-2.5.8-jruby-9.2.20.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.20.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.5.8-jruby-9.2.20.1.sh
+++ b/rubies/heroku-22/ruby-2.5.8-jruby-9.2.20.1.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.20.1 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.5.8-jruby-9.2.21.0.sh
+++ b/rubies/heroku-22/ruby-2.5.8-jruby-9.2.21.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.2.21.0 -e RUBY_VERSION=2.5.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.0.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.0.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.0.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.1.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.1.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.1.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.10.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.10.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.10.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.2.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.2.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.2.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.3.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.3.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.3.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.4.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.4.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.4.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.5.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.5.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.5.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.6.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.6.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.6.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.7.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.7.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.7.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.8.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.8.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.8.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-2.6.8-jruby-9.3.9.0.sh
+++ b/rubies/heroku-22/ruby-2.6.8-jruby-9.3.9.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.3.9.0 -e RUBY_VERSION=2.6.8 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-3.1.0-jruby-9.4.0.0.sh
+++ b/rubies/heroku-22/ruby-3.1.0-jruby-9.4.0.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.4.0.0 -e RUBY_VERSION=3.1.0 -t hone/jruby-builder:$STACK

--- a/rubies/heroku-22/ruby-3.1.0-jruby-9.4.1.0.sh
+++ b/rubies/heroku-22/ruby-3.1.0-jruby-9.4.1.0.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-source `dirname $0`/../common.sh
-source `dirname $0`/common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=9.4.1.0 -e RUBY_VERSION=3.1.0 -t hone/jruby-builder:$STACK


### PR DESCRIPTION
Prior to https://github.com/heroku/docker-heroku-jruby-builder/pull/33 a script was generated for every Ruby version on every stack to execute docker. This is no longer needed, we can get rid of this directory.